### PR TITLE
Add automatic redirect for authenticated users from home to dashboard

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,37 @@
+import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs'
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export async function middleware(req: NextRequest) {
+  const res = NextResponse.next()
+  const supabase = createMiddlewareClient({ req, res })
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  // If user is authenticated and trying to access the home page, redirect to dashboard
+  if (user && req.nextUrl.pathname === '/') {
+    return NextResponse.redirect(new URL('/dashboard', req.url))
+  }
+
+  // If user is not authenticated and trying to access protected routes, redirect to signin
+  if (!user && req.nextUrl.pathname.startsWith('/dashboard')) {
+    return NextResponse.redirect(new URL('/auth/signin', req.url))
+  }
+
+  return res
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     * - public folder
+     */
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
+}


### PR DESCRIPTION
- Add middleware.ts for server-side authentication-based redirects
- Authenticated users visiting / are automatically redirected to /dashboard
- Unauthenticated users visiting /dashboard are redirected to /auth/signin
- Landing page remains accessible at / for new visitors and SEO
- Uses Next.js middleware for optimal performance at the edge