### PR TITLE
Fix QR code published tab not being clickable

### DIFF
--- a/components/pages/dashboard/editor/PageEditor.tsx
+++ b/components/pages/dashboard/editor/PageEditor.tsx
@@ -111,7 +111,10 @@ export default function PageEditor({ initialConfig, onSave, saveStatus = 'saved'
       onPublishingChange(true);
     }
     try {
-      // Create config with section state for publishing
+      // First, call the original handlePublish to update publishedUrl and show modal
+      await originalHandlePublish();
+      
+      // Then do our custom save with section state
       const config = {
         page_content: pageContent,
         page_style: pageStyle,
@@ -135,7 +138,7 @@ export default function PageEditor({ initialConfig, onSave, saveStatus = 'saved'
         onPublishingChange(false);
       }
     }
-  }, [pageContent, pageStyle, templateId, id, originalPrompt, sectionState, onSave, onPublishingChange]);
+  }, [pageContent, pageStyle, templateId, id, originalPrompt, sectionState, onSave, onPublishingChange, originalHandlePublish]);
 
   // Create a wrapper for handleSave that includes section state
   const handleSaveWithSectionState = React.useCallback(async () => {

--- a/components/widgets/MobilePreviewQR.tsx
+++ b/components/widgets/MobilePreviewQR.tsx
@@ -32,6 +32,19 @@ export default function MobilePreviewQR({ pageUrl, pageId, previewUrl, isPublish
   const hasPublishedUrl = pageUrl && pageUrl.trim() !== '';
   const hasAnyUrl = hasPreviewUrl || hasPublishedUrl;
 
+  // Debug logging
+  React.useEffect(() => {
+    console.log('MobilePreviewQR Debug:', {
+      pageUrl,
+      clientPreviewUrl,
+      hasPreviewUrl,
+      hasPublishedUrl,
+      hasAnyUrl,
+      isPublished,
+      autoOpen
+    });
+  }, [pageUrl, clientPreviewUrl, hasPreviewUrl, hasPublishedUrl, hasAnyUrl, isPublished, autoOpen]);
+
   // Handle auto-open functionality
   React.useEffect(() => {
     if (autoOpen && hasAnyUrl) {


### PR DESCRIPTION
- Modified handlePublish in PageEditor to call originalHandlePublish first
- This ensures publishedUrl gets updated in usePageEditor hook
- Added debug logging to MobilePreviewQR to help diagnose URL issues
- Now the published tab should be clickable after publishing

The issue was that our custom handlePublish wrapper wasn't updating the publishedUrl state in the usePageEditor hook, so the QR component couldn't detect the published URL.